### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Replay files contain rich data about every frame: positions, action states, inpu
 
 Find replays within a folder quickly using a specific combination of characters, stage, Slippi connect code, Slippi display name, or in-game nametag.
 
+File names of filtered games are now printed to the console. Can be used to pick files to add to Project Clippi or use in conjunction with forked version of slp-to-mp4 for simplified batch conversion of matches. See fork for details:
+https://github.com/Gmarcott42/slp-to-mp4
+
 ### Insights
 
 Important moments in the selected replay are automatically detected and listed, so less time is needed to find specific situations when browsing.

--- a/src/state/selectionStore.tsx
+++ b/src/state/selectionStore.tsx
@@ -144,7 +144,7 @@ function applyFilters(
   const namesNeeded = filters
     .filter((filter) => filter.type === "codeOrName")
     .map((filter) => filter.label);
-  return filesWithSettings.filter(([file, gameSettings]) => {
+  const filtered = filesWithSettings.filter(([file, gameSettings]) => {
     const areCharactersSatisfied = Object.entries(charactersNeeded).every(
       ([character, amountRequired]) =>
         gameSettings.playerSettings.filter(
@@ -165,6 +165,12 @@ function applyFilters(
     );
     return stagePass && areCharactersSatisfied && areNamesSatisfied;
   });
+  let filenames = [''];
+  filtered.forEach((element) => {
+    filenames.push(element[0]['name']);
+  });
+  console.log(filenames);
+  return filtered;
 }
 
 function wrap(index: number, limit: number): number {


### PR DESCRIPTION
After any filter selection, array of matching filenames is printed to the console. Useful for finding a large selection of matches to add to Project Clippi. Also can be used with slp-to-mp4 fork to have a selection of matches converted without picking each one out individually. 