### PR TITLE
Show Fountain of Dreams platform height changes

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,2 @@
+export const fodInitialLeftPlatformHeight = 20.0; // 16.125 / 0.80625
+export const fodInitialRightPlatformHeight = 27.44186047; // 22.125 / 0.80625

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -86,6 +86,7 @@ export interface Frame {
   /** Indexed by playerIndex (port - 1). Do not check length */
   readonly players: PlayerUpdate[];
   readonly items: ItemUpdate[];
+  readonly stage: StageState;
 }
 
 /** The inputs applied during this frame and the resulting state(s) */
@@ -209,6 +210,18 @@ export interface ItemUpdate {
   /** Mewtwo/Samus */
   readonly chargeShotChargeLevel: number;
   readonly owner: number;
+}
+
+export interface StageUpdate {
+  readonly frameNumber: number;
+  readonly fodPlatform: number; // 0 = right, 1 = left
+  readonly fodPlatformHeight: number;
+}
+
+export interface StageState {
+  readonly frameNumber: number;
+  readonly fodLeftPlatformHeight: number;
+  readonly fodRightPlatformHeight: number;
 }
 
 /**

--- a/src/components/viewer/Stage.tsx
+++ b/src/components/viewer/Stage.tsx
@@ -1,4 +1,8 @@
 import { createMemo, For, Match, Switch } from "solid-js";
+import {
+  fodInitialLeftPlatformHeight,
+  fodInitialRightPlatformHeight,
+} from "~/common/constants";
 import { stageNameByExternalId } from "~/common/ids";
 import { replayStore } from "~/state/replayStore";
 
@@ -345,11 +349,26 @@ function FountainOfDreams() {
     "-63.35, -4.5",
     "-63.33, 0.62",
   ];
-  const platforms = [
-    ["-49.5, 16.125", "-21, 16.125"],
-    ["21, 22.125", "49.5, 22.125"],
-    ["-14.25, 42.75", "14.25, 42.75"],
-  ];
+
+  // Multiplication factor from game platform height to viewer platform height.
+  const platformHeightCoefficient = 0.80625;
+
+  const platforms = createMemo(() => {
+    const gameHeightL =
+      replayStore.replayData?.frames[replayStore.frame].stage
+        .fodLeftPlatformHeight ?? fodInitialLeftPlatformHeight;
+    const gameHeightR =
+      replayStore.replayData?.frames[replayStore.frame].stage
+        .fodRightPlatformHeight ?? fodInitialRightPlatformHeight;
+    const heightL = gameHeightL * platformHeightCoefficient;
+    const heightR = gameHeightR * platformHeightCoefficient;
+    return [
+      [`-49.5, ${heightL}`, `-21, ${heightL}`],
+      [`21, ${heightR}`, `49.5, ${heightR}`],
+      ["-14.25, 42.75", "14.25, 42.75"],
+    ];
+  });
+
   const blastzones = [
     [-198.75, -146.25],
     [198.75, 202.5],
@@ -358,7 +377,7 @@ function FountainOfDreams() {
     <>
       <Grid blastzones={blastzones} />
       <polyline points={mainStage.join(" ")} class="fill-slate-800" />
-      <For each={platforms.slice(0, 2)}>
+      <For each={platforms().slice(0, 2)}>
         {(points) => (
           <polyline
             points={points.join(" ")}
@@ -368,7 +387,7 @@ function FountainOfDreams() {
         )}
       </For>
       <polyline
-        points={platforms[platforms.length - 1].join(" ")}
+        points={platforms()[platforms().length - 1].join(" ")}
         class="stroke-slate-800"
       />
       <rect


### PR DESCRIPTION
This PR parses and uses the [0x3F FOD Platforms event](https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md#fod-platforms) to display the correct FoD platform heights. 

It does so by adding a `stage` property to `Frame`, which stores stage state for the given frame. The platform update event is parsed as a `StageUpdate`, which is a transient type not stored within the final `ReplayData`, and instead only used to compute the current stage state for each frame.