### PR TITLE
Fix display name length

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -499,7 +499,7 @@ function parseGameStartEvent(
         settings.replayFormatVersion,
         "3.9.0.0",
         offset + 0x1a5 + 0x1f * playerIndex,
-        16
+        31
       ),
       connectCode: readShiftJisString(
         rawData,


### PR DESCRIPTION
The Slippi spec has the display name as 15 JIS characters + null terminator. Since JIS characters can be either 1 or 2 bytes, and the terminator is 1 byte, this means the display name can be 31 bytes long. This can also be seen by the `0x1F * i` term in the offset.