### PR TITLE
Add display of left stick coordinates

### DIFF
--- a/src/components/panels/Inputs.tsx
+++ b/src/components/panels/Inputs.tsx
@@ -140,6 +140,23 @@ function Controller(
           cy={274.5 - (inputs()?.processed.joystickY ?? 0) * 34}
           r={35.1}
         />
+        {/* Left stick numeric values */}
+        <text
+          x={20}
+          y={370}
+          text-anchor="start"
+          class="text-xl fill-black font-mono font-bold"
+        >
+          X: {(inputs()?.processed.joystickX ?? 0).toFixed(3).padStart(6, '+')}
+        </text>
+        <text
+          x={20}
+          y={395}
+          text-anchor="start"
+          class="text-xl fill-black font-mono font-bold"
+        >
+          Y: {(inputs()?.processed.joystickY ?? 0).toFixed(3).padStart(6, '+')}
+        </text>
         <path
           id="cStickCutout"
           fill="transparent"


### PR DESCRIPTION
You may want to move this number somewhere else, but here's a proof of concept.

I'm not sure the preferred coordinate system for gcc.

Also it's a bit small to see the value the way I did it.

<img width="864" height="864" alt="image" src="https://github.com/user-attachments/assets/dd3f2b72-e4ab-4235-b82e-bbc39a1b1723" />

Closes #58 