### PR TITLE
Add ability to generate TM-CE savestates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@gcpreston/tm_replay_wasm": "^0.1.1",
         "@jsonjoy.com/json-pack": "^1.0.2",
         "@shelacek/ubjson": "^1.1.1",
         "@solid-primitives/raf": "^2.1.4",
@@ -35,6 +36,7 @@
         "typescript": "^4.9.3",
         "vite": "^3.2.5",
         "vite-plugin-solid": "^2.4.0",
+        "vite-plugin-wasm": "^3.5.0",
         "vite-tsconfig-paths": "^4.0.1",
         "wrangler": "^3.52.0"
       }
@@ -1090,6 +1092,11 @@
         "@floating-ui/core": "^1.0.1"
       }
     },
+    "node_modules/@gcpreston/tm_replay_wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@gcpreston/tm_replay_wasm/-/tm_replay_wasm-0.1.1.tgz",
+      "integrity": "sha512-xC27+TWR/SDr9DMxaBP5G6+PCQRHKcIuXap8T8p2GkXUo+KrjeRTZM8JDg5Jw0vNwUHlvPX7ULk/cF3thp7dQQ=="
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -1618,21 +1625,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bufferutil": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
-      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/camelcase-css": {
@@ -2659,19 +2651,6 @@
         "node": ">= 6.13.0"
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
@@ -3322,21 +3301,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3408,6 +3372,16 @@
       "peerDependencies": {
         "solid-js": "^1.3.17",
         "vite": "^3.0.0"
+      }
+    },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.5.0.tgz",
+      "integrity": "sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7"
       }
     },
     "node_modules/vite-tsconfig-paths": {
@@ -4299,6 +4273,11 @@
         "@floating-ui/core": "^1.0.1"
       }
     },
+    "@gcpreston/tm_replay_wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@gcpreston/tm_replay_wasm/-/tm_replay_wasm-0.1.1.tgz",
+      "integrity": "sha512-xC27+TWR/SDr9DMxaBP5G6+PCQRHKcIuXap8T8p2GkXUo+KrjeRTZM8JDg5Jw0vNwUHlvPX7ULk/cF3thp7dQQ=="
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -4702,17 +4681,6 @@
         "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.9"
-      }
-    },
-    "bufferutil": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
-      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "node-gyp-build": "^4.3.0"
       }
     },
     "camelcase-css": {
@@ -5362,14 +5330,6 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true
     },
-    "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node-releases": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
@@ -5783,17 +5743,6 @@
         "picocolors": "^1.0.0"
       }
     },
-    "utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "node-gyp-build": "^4.3.0"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5826,6 +5775,13 @@
         "solid-refresh": "^0.4.1",
         "vitefu": "^0.1.1"
       }
+    },
+    "vite-plugin-wasm": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.5.0.tgz",
+      "integrity": "sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ==",
+      "dev": true,
+      "requires": {}
     },
     "vite-tsconfig-paths": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier -w src/"
   },
   "dependencies": {
+    "@gcpreston/tm_replay_wasm": "^0.1.1",
     "@jsonjoy.com/json-pack": "^1.0.2",
     "@shelacek/ubjson": "^1.1.1",
     "@solid-primitives/raf": "^2.1.4",
@@ -37,6 +38,7 @@
     "typescript": "^4.9.3",
     "vite": "^3.2.5",
     "vite-plugin-solid": "^2.4.0",
+    "vite-plugin-wasm": "^3.5.0",
     "vite-tsconfig-paths": "^4.0.1",
     "wrangler": "^3.52.0"
   }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -1,4 +1,11 @@
 import { unzipSync } from "fflate";
+import { construct_tm_replay_from_slp_in_js } from "@gcpreston/tm_replay_wasm";
+
+import { currentSelectionStore } from "~/state/selectionStore";
+import { replayStore } from "~/state/replayStore";
+import { createToast } from "~/components/common/toaster";
+
+const SAVESTATE_LENGTH = 300;
 
 export async function filterFiles(files: File[]): Promise<File[]> {
   const slpFiles = files.filter((file) => file.name.endsWith(".slp"));
@@ -14,4 +21,64 @@ export async function unzip(zipFile: File): Promise<File[]> {
   return Object.entries(fileBuffers).map(
     ([name, buffer]) => new File([buffer], name)
   );
+}
+
+export function downloadFile(f: File) {
+  const element = document.createElement("a");
+  const url = URL.createObjectURL(f);
+  element.href = url;
+  element.setAttribute("download", f.name);
+  element.style.display = "none";
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+}
+
+export async function generateSavestate(
+  replayFile: File,
+  name: string,
+  lowPort: boolean
+) {
+  const bytes = await replayFile.arrayBuffer();
+
+  return construct_tm_replay_from_slp_in_js(
+    new Uint8Array(bytes),
+    lowPort,
+    replayStore.frame,
+    SAVESTATE_LENGTH,
+    name,
+    BigInt(0)
+  );
+}
+
+export async function downloadCurrentSavestate(lowPort: boolean) {
+  const [replayFile, _stub] = currentSelectionStore().data.selectedFileAndStub!;
+
+  if (replayFile) {
+    const d = new Date();
+    const name =
+      "savestate" +
+      d.getFullYear() +
+      (d.getMonth() + 1) +
+      d.getDate() +
+      d.getHours() +
+      d.getMinutes() +
+      d.getSeconds();
+
+    try {
+      const savestate = await generateSavestate(replayFile, name, lowPort);
+      const blob = new Blob([savestate]);
+      const file = new File([blob], `${name}.gci`, {
+        type: "application/octet-stream",
+      });
+      downloadFile(file);
+    } catch (error) {
+      createToast({
+        title: "Error generating savestate",
+        duration: 5000,
+        render: () => error,
+        placement: "top-end",
+      });
+    }
+  }
 }

--- a/src/components/panels/Inputs.tsx
+++ b/src/components/panels/Inputs.tsx
@@ -6,6 +6,7 @@ import {
 } from "~/common/ids";
 import { PlayerInputs } from "~/common/types";
 import { getPlayerColor, replayStore } from "~/state/replayStore";
+import { downloadCurrentSavestate } from "~/common/util";
 
 export function Inputs() {
   const indexes = [0, 1, 2, 3];
@@ -34,6 +35,14 @@ function Summary(props: { playerIndex: number }) {
         !renderData.playerState.isNana
     );
   });
+
+  // we are the low port if there is a player on the higher port
+  const lowPort = Boolean(
+    replayStore.renderDatas.find(
+      (renderData) => renderData.playerInputs.playerIndex > props.playerIndex
+    )
+  );
+
   return (
     <Show when={settings()}>
       <div>
@@ -67,6 +76,14 @@ function Summary(props: { playerIndex: number }) {
               {renderData()!.playerState.hurtboxCollisionState}
             </div>
           </Show>
+
+          <button
+            type="button"
+            class="rounded border px-1 hover:bg-slate-100"
+            onClick={() => downloadCurrentSavestate(lowPort)}
+          >
+            Download savestate
+          </button>
         </Show>
       </div>
     </Show>

--- a/src/components/panels/Inputs.tsx
+++ b/src/components/panels/Inputs.tsx
@@ -36,13 +36,6 @@ function Summary(props: { playerIndex: number }) {
     );
   });
 
-  // we are the low port if there is a player on the higher port
-  const lowPort = Boolean(
-    replayStore.renderDatas.find(
-      (renderData) => renderData.playerInputs.playerIndex > props.playerIndex
-    )
-  );
-
   return (
     <Show when={settings()}>
       <div>
@@ -77,13 +70,23 @@ function Summary(props: { playerIndex: number }) {
             </div>
           </Show>
 
-          <button
-            type="button"
-            class="rounded border px-1 hover:bg-slate-100"
-            onClick={() => downloadCurrentSavestate(lowPort)}
-          >
-            Download savestate
-          </button>
+          {replayStore.renderDatas.length == 2 &&
+            <button
+              type="button"
+              class="rounded border px-1 hover:bg-slate-100"
+              onClick={() => {
+                // we are the low port if there is a player on the higher port
+                const lowPort = Boolean(
+                  replayStore.renderDatas.find(
+                    (renderData) => renderData.playerInputs.playerIndex > props.playerIndex
+                  )
+                );
+                downloadCurrentSavestate(lowPort);
+              }}
+            >
+              Download savestate
+            </button>
+          }
         </Show>
       </div>
     </Show>

--- a/src/components/panels/TopBar.tsx
+++ b/src/components/panels/TopBar.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, ArrowRight, DownloadIcon } from "~/components/common/icons";
 import { OpenMenu } from "~/components/common/OpenMenu";
 import { UploadDialog } from "~/components/panels/UploadDialog";
 import { currentSelectionStore } from "~/state/selectionStore";
+import { downloadFile } from "~/common/util";
 
 export function TopBar() {
   return (
@@ -32,7 +33,7 @@ export function TopBar() {
             onClick={() => currentSelectionStore().nextFile()}
           />
         </div>
-        <div class="flex h-8 gap-4 justify-self-end">
+        <div class="flex h-8 gap-2 justify-self-end">
           <DownloadIcon
             class="h-8 w-8"
             role="button"
@@ -43,14 +44,7 @@ export function TopBar() {
                 return;
               }
               const file = currentSelectionStore().data.selectedFileAndStub![0];
-              const element = document.createElement("a");
-              const url = URL.createObjectURL(file);
-              element.href = url;
-              element.setAttribute("download", file.name);
-              element.style.display = "none";
-              document.body.appendChild(element);
-              element.click();
-              document.body.removeChild(element);
+              downloadFile(file);
             }}
             title="download .slp"
           />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import solidPlugin from "vite-plugin-solid";
+import wasmPlugin from "vite-plugin-wasm";
 import viteTsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   assetsInclude: [/.*zip$/, /.*ttf$/],
-  plugins: [solidPlugin(), viteTsconfigPaths()],
+  plugins: [solidPlugin(), wasmPlugin(), viteTsconfigPaths()],
   resolve: {
     conditions: ["browser"],
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   resolve: {
     conditions: ["browser"],
   },
+  build: { target: "esnext" }
 });


### PR DESCRIPTION
This PR adds the ability to create TrainingMode-CommunityEdition savestates directly from the browser. This utilizes Aitch's `tm_replay` built to Wasm; specifically [a branch I made to make it Wasm-compatible](https://github.com/gcpreston/tm_replay/tree/wasm). The branch is compiled and hosted on npm at [`@gcpreston/tm_replay_wasm`](https://www.npmjs.com/package/@gcpreston/tm_replay_wasm), so none of the Rust source is included within this project's repository.

The "Download savestate" button only shows up for 1v1 matches.

<img width="1438" height="712" alt="Screenshot 2026-02-01 at 12 19 59 AM" src="https://github.com/user-attachments/assets/645c0c72-04c7-4e03-9f32-a0197e789d72" />
